### PR TITLE
Removed duplicate unique Identifier

### DIFF
--- a/src/Acl/Entity/DoctrineAclRole.php
+++ b/src/Acl/Entity/DoctrineAclRole.php
@@ -42,7 +42,7 @@ class DoctrineAclRole extends AclRole
     /**
      * @var integer
      * @ORM\Id
-     * @ORM\Column(type="integer", unique=true, nullable=false)
+     * @ORM\Column(type="integer", nullable=false)
      * @ORM\GeneratedValue(strategy="AUTO")
      */
     protected $id;


### PR DESCRIPTION
Column $id is already marked as unique with the @\Id tag.  Adding unique and id to this field causes non-index db's to blow up on create.