### PR TITLE
Removed Unique from name and email.

### DIFF
--- a/src/User/Entity/DoctrineUser.php
+++ b/src/User/Entity/DoctrineUser.php
@@ -66,13 +66,13 @@ class DoctrineUser extends User
 
     /**
      * @var string $email
-     * @ORM\Column(type="string", length=255, unique=true, nullable=true)
+     * @ORM\Column(type="string", length=255, nullable=true)
      */
     protected $email;
 
     /**
      * @var string $name
-     * @ORM\Column(type="string", length=255, unique=true, nullable=true)
+     * @ORM\Column(type="string", length=255, nullable=true)
      */
     protected $name;
 }


### PR DESCRIPTION
Remove the unique flag from name and email.   First we can have users with the same name... "John Smith" or "John".  Also, some site owners may share email addresses.   Seems if someone wants to restrict duplicate emails, this should be handled outside of the DB.

Also, unique + nullable seems a bit odd.  